### PR TITLE
changed some metadata properties to be able to publish on Zenodo

### DIFF
--- a/.github/zenodo/metadata.json
+++ b/.github/zenodo/metadata.json
@@ -1,7 +1,6 @@
 {
   "title": "TikZ-trackschematic",
   "version": "%%[SCRIPT]", 
-  "publication_date": "%%[SCRIPT]", 
   "creators": [
     {
       "orcid": "0000-0002-9384-8945", 
@@ -23,8 +22,5 @@
   },
   "language": "eng",
   "access_right": "open", 
-  "resource_type": {
-    "type": "software", 
-    "title": "Software"
-  }
+  "upload_type": "software"
 }


### PR DESCRIPTION
This PR updates the metadata used to publish to Zenodo so that it passes validation and can be ingested. I tried the following steps with the updated data:

```shell
source ~/tokens/sandbox.zenodo.org  # add my ZENODO_SANDBOX_ACCESS_TOKEN to the env
zenodraft --sandbox deposition create in-new-collection 
1048737
zenodraft --sandbox file add 1048737 build.sh    # upload an arbitrary file
zenodraft --sandbox metadata update 1048737 .github/zenodo/metadata.json
zenodraft --sandbox deposition publish 1048737
```

This resulted in https://sandbox.zenodo.org/record/1048737. Some more documentation about Zenodo's REST API and the properties that are supported: https://developers.zenodo.org. There's also https://zenodo.org/schemas/records/record-v1.0.0.json, a JSONschema schema that Zenodo publishes, but there is some discussion about whether this is accurate: https://github.com/zenodo/zenodo/issues/2294. 

Hope this helps! Best regards,
-Jurriaan